### PR TITLE
Feature/auth

### DIFF
--- a/moa2/src/main/java/com/moa2/InitDb.java
+++ b/moa2/src/main/java/com/moa2/InitDb.java
@@ -23,9 +23,7 @@ public class InitDb {
     @Transactional
     @RequiredArgsConstructor
     static class InitService {
-        private final MemberService memberService;
         private final AuthorityRepository authorityRepository;
-        private final PasswordEncoder encoder;
         public void dbInit() {
             authorityRepository.save(new Authority("ROLE_USER"));
             authorityRepository.save(new Authority("ROLE_ADMIN"));

--- a/moa2/src/main/java/com/moa2/InitDb.java
+++ b/moa2/src/main/java/com/moa2/InitDb.java
@@ -1,6 +1,7 @@
 package com.moa2;
 
 import com.moa2.domain.member.Authority;
+import com.moa2.domain.member.Member;
 import com.moa2.repository.member.AuthorityRepository;
 import com.moa2.service.member.MemberService;
 import jakarta.annotation.PostConstruct;
@@ -24,9 +25,19 @@ public class InitDb {
     @RequiredArgsConstructor
     static class InitService {
         private final AuthorityRepository authorityRepository;
+        private final MemberService memberService;
+        private final PasswordEncoder passwordEncoder;
         public void dbInit() {
             authorityRepository.save(new Authority("ROLE_USER"));
             authorityRepository.save(new Authority("ROLE_ADMIN"));
+
+            Member member = new Member();
+            member.setNickname("admin");
+            member.setEmail("123@com");
+            member.setPassword(passwordEncoder.encode("1111"));
+            member.getAuthorities().add(authorityRepository.findByName("ROLE_ADMIN"));
+            member.getAuthorities().add(authorityRepository.findByName("ROLE_USER"));
+            memberService.register(member);
         }
     }
 }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -23,16 +23,8 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity register(@Valid @RequestBody SignupDto signupDto) {
         Member user = memberService.createUser(signupDto);
-
-        ResponseEntity responseEntity = null;
-        try {
-            memberService.register(user);
-            responseEntity = new ResponseEntity("registration success", HttpStatus.CREATED);
-
-        } catch (Exception e) {
-            responseEntity = new ResponseEntity("registration fail : " + e.getMessage(), HttpStatus.BAD_REQUEST);
-        }
-        return responseEntity;
+        memberService.register(user);
+        return new ResponseEntity("registration success", HttpStatus.CREATED);
     }
 
     @PostMapping("/login")

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -84,4 +84,11 @@ public class AuthController {
                 .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
                 .body("refresh success");
     }
+
+    @GetMapping("/test-admin")
+    public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
+        Long memberId = authService.getMemberId(accessTokenInHeader);
+        String memberInfo = memberService.getMemberInfo(memberId);
+        return ResponseEntity.ok().body(memberInfo);
+    }
 }

--- a/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
+++ b/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.moa2.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    // 500
+    @ExceptionHandler(Exception.class)
+    @ResponseBody
+    public ResponseEntity<Object> handleIllegalArgumentException(Exception ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
+++ b/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
@@ -1,13 +1,29 @@
 package com.moa2.exception;
 
+import com.moa2.exception.jwt.InvalidTokenRequestException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    // 400
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseBody
+    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
+    // 401
+    @ExceptionHandler({InvalidTokenRequestException.class, BadCredentialsException.class})
+    @ResponseBody
+    public ResponseEntity<Object> handleIllegalArgumentException(InvalidTokenRequestException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
 
     // 500
     @ExceptionHandler(Exception.class)

--- a/moa2/src/main/java/com/moa2/exception/InvalidTokenRequestException.java
+++ b/moa2/src/main/java/com/moa2/exception/InvalidTokenRequestException.java
@@ -1,0 +1,15 @@
+package com.moa2.exception;
+
+public class InvalidTokenRequestException extends RuntimeException {
+
+    private final String tokenType;
+    private final String token;
+    private final String message;
+
+    public InvalidTokenRequestException(String tokenType, String token, String message) {
+        super(String.format("%s: [%s] token: [%s] ", message, tokenType, token));
+        this.tokenType = tokenType;
+        this.token = token;
+        this.message = message;
+    }
+}

--- a/moa2/src/main/java/com/moa2/exception/jwt/InvalidTokenRequestException.java
+++ b/moa2/src/main/java/com/moa2/exception/jwt/InvalidTokenRequestException.java
@@ -1,4 +1,4 @@
-package com.moa2.exception;
+package com.moa2.exception.jwt;
 
 public class InvalidTokenRequestException extends RuntimeException {
 

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers("api/auth/register", "api/auth/login", "api/auth/refresh").permitAll()
                 .requestMatchers("api/auth/mypage").hasAuthority("ROLE_USER")
+                .requestMatchers("api/auth/test-admin").hasAuthority("ROLE_ADMIN")
                 .anyRequest().authenticated();
 
         return http.build();

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -29,7 +29,6 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtFilter jwtFilter;
-
     @Bean
     SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
         http.cors().configurationSource(new CorsConfigurationSource() {
@@ -49,6 +48,8 @@ public class SecurityConfig {
 
         http
                 .csrf().disable()
+                .httpBasic().disable()
+                .formLogin().disable()
 
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling()
@@ -62,9 +63,9 @@ public class SecurityConfig {
 
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers("api/auth/register", "api/auth/login", "api/auth/refresh").permitAll()
-                .requestMatchers("api/auth/mypage").hasAuthority("ROLE_USER")
                 .requestMatchers("api/auth/test-admin").hasAuthority("ROLE_ADMIN")
+                .requestMatchers("api/auth/mypage").hasAuthority("ROLE_USER")
+                .requestMatchers("api/auth/register", "api/auth/login", "api/auth/refresh").permitAll()
                 .anyRequest().authenticated();
 
         return http.build();

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtFilter.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtFilter.java
@@ -26,14 +26,15 @@ public class JwtFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
         String jwt = resolveToken(request);
-        String requestURI = request.getRequestURI();
 
-        if (jwt != null && jwtValidator.validateToken(jwt)) {
-            Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            log.debug("set Authentication to security context for '{}', uri: {}", authentication.getName(), requestURI);
-        } else {
-            log.debug("no valid JWT token found, uri: {}", requestURI);
+        try {
+            if (jwt != null) {
+                jwtValidator.validateToken(jwt);
+                Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            log.error("Could not set user authentication in security context", e);
         }
         filterChain.doFilter(request, response);
     }

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtTokenProvider.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtTokenProvider.java
@@ -17,7 +17,6 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.security.Key;
 import java.util.Collection;
@@ -88,8 +87,6 @@ public class JwtTokenProvider implements InitializingBean {
         return new TokenDto(accessToken, refreshToken);
     }
 
-
-    @Transactional
     public Authentication getAuthentication(String token) {
         Claims claims = getClaims(token);
 

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
@@ -44,7 +44,7 @@ public class JwtValidator {
     public boolean validateRefreshToken(String refreshToken) {
         validateToken(refreshToken);
         if (!refreshTokenService.isExistRefreshToken(refreshToken)) {
-            throw new InvalidTokenRequestException("JWT", refreshToken, "Invalid refresh token.");
+            throw new InvalidTokenRequestException("JWT", refreshToken, "Refresh token is expired or deleted.");
         }
         return true;
     }
@@ -52,7 +52,7 @@ public class JwtValidator {
     public boolean validateAccessToken(String accessToken) {
         validateToken(accessToken);
         if (!accessTokenService.isExistAccessToken(accessToken)) {
-            throw new InvalidTokenRequestException("JWT", accessToken, "Invalid access token.");
+            throw new InvalidTokenRequestException("JWT", accessToken, "Access token is expired or deleted.");
         }
         return true;
     }

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
@@ -1,6 +1,6 @@
 package com.moa2.security.jwt;
 
-import com.moa2.exception.InvalidTokenRequestException;
+import com.moa2.exception.jwt.InvalidTokenRequestException;
 import com.moa2.service.auth.AccessTokenService;
 import com.moa2.service.auth.RefreshTokenService;
 import io.jsonwebtoken.ExpiredJwtException;

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtValidator.java
@@ -1,10 +1,12 @@
 package com.moa2.security.jwt;
 
+import com.moa2.exception.InvalidTokenRequestException;
 import com.moa2.service.auth.AccessTokenService;
 import com.moa2.service.auth.RefreshTokenService;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,35 +22,37 @@ public class JwtValidator {
     public boolean validateToken(String authToken) {
         try {
             jwtTokenProvider.getClaims(authToken);
-            return true;
-        } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
-            log.info("Invalid JWT signature.");
-            log.trace("Invalid JWT signature trace: {}", e);
+        } catch (SignatureException e) {
+            log.error("Invalid JWT signature.");
+            throw new InvalidTokenRequestException("JWT", authToken, "Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token.");
+            throw new InvalidTokenRequestException("JWT", authToken, "Invalid JWT token.");
         } catch (ExpiredJwtException e) {
-            log.info("Expired JWT token.");
-            log.trace("Expired JWT token trace: {}", e);
+            log.error("Expired JWT token.");
+            throw new InvalidTokenRequestException("JWT", authToken, "Expired JWT token.");
         } catch (UnsupportedJwtException e) {
-            log.info("Unsupported JWT token.");
-            log.trace("Unsupported JWT token trace: {}", e);
+            log.error("Unsupported JWT token.");
+            throw new InvalidTokenRequestException("JWT", authToken, "Unsupported JWT token.");
         } catch (IllegalArgumentException e) {
-            log.info("JWT token compact of handler are invalid.");
-            log.trace("JWT token compact of handler are invalid trace: {}", e);
+            log.error("JWT claims string is empty.");
+            throw new InvalidTokenRequestException("JWT", authToken, "JWT claims string is empty.");
         }
-        return false;
+        return true;
     }
 
     public boolean validateRefreshToken(String refreshToken) {
-        if (!validateToken(refreshToken) ||
-                !refreshTokenService.isExistRefreshToken(refreshToken)) {
-            return false;
+        validateToken(refreshToken);
+        if (!refreshTokenService.isExistRefreshToken(refreshToken)) {
+            throw new InvalidTokenRequestException("JWT", refreshToken, "Invalid refresh token.");
         }
         return true;
     }
 
     public boolean validateAccessToken(String accessToken) {
-        // AT는 filter 에서 validateToken 을 이미 통과함
+        validateToken(accessToken);
         if (!accessTokenService.isExistAccessToken(accessToken)) {
-            return false;
+            throw new InvalidTokenRequestException("JWT", accessToken, "Invalid access token.");
         }
         return true;
     }

--- a/moa2/src/main/java/com/moa2/service/auth/AccessTokenService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AccessTokenService.java
@@ -3,10 +3,8 @@ package com.moa2.service.auth;
 import com.moa2.repository.redis.RedisRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 public class AccessTokenService {
     private final RedisRepository redisRepository;
     private final long accessTokenValidityInSeconds;

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -12,12 +12,10 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class AuthService {
 
     private final RefreshTokenService refreshTokenService;
@@ -26,7 +24,6 @@ public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final JwtValidator jwtValidator;
 
-    @Transactional
     public TokenDto login(@Valid LoginDto loginDto) {
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginDto.getEmail(), loginDto.getPassword());
@@ -37,7 +34,6 @@ public class AuthService {
         return jwtTokenProvider.createTokens(authentication);
     }
 
-    @Transactional
     public void logout(String accessTokenInHeader) {
         String accessToken = resolveToken(accessTokenInHeader);
         if (!jwtValidator.validateAccessToken(accessToken)) {
@@ -48,7 +44,6 @@ public class AuthService {
         refreshTokenService.deleteRefreshToken(refreshToken);
     }
 
-    @Transactional
     public TokenDto refresh(String refreshToken) {
         if (!jwtValidator.validateRefreshToken(refreshToken)) {
             throw new IllegalArgumentException("Invalid token");

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -1,6 +1,7 @@
 package com.moa2.service.auth;
 
 import com.moa2.dto.auth.LoginDto;
+import com.moa2.exception.jwt.InvalidTokenRequestException;
 import com.moa2.security.jwt.JwtTokenProvider;
 import com.moa2.security.jwt.JwtValidator;
 import com.moa2.dto.auth.TokenDto;
@@ -36,18 +37,15 @@ public class AuthService {
 
     public void logout(String accessTokenInHeader) {
         String accessToken = resolveToken(accessTokenInHeader);
-        if (!jwtValidator.validateAccessToken(accessToken)) {
-            throw new IllegalArgumentException("Invalid token");
-        }
+        jwtValidator.validateAccessToken(accessToken);
+
         String refreshToken = accessTokenService.getAccessToken(accessToken);
         accessTokenService.deleteAccessToken(accessToken);
         refreshTokenService.deleteRefreshToken(refreshToken);
     }
 
     public TokenDto refresh(String refreshToken) {
-        if (!jwtValidator.validateRefreshToken(refreshToken)) {
-            throw new IllegalArgumentException("Invalid token");
-        }
+        jwtValidator.validateRefreshToken(refreshToken);
 
         Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
 
@@ -59,9 +57,7 @@ public class AuthService {
 
 
     public Long getMemberId(String accessTokenInHeader) {
-        if (!jwtValidator.validateAccessToken(resolveToken(accessTokenInHeader))) {
-            throw new IllegalArgumentException("Invalid token");
-        }
+        jwtValidator.validateAccessToken(resolveToken(accessTokenInHeader));
         String accessToken = resolveToken(accessTokenInHeader);
         Long memberId = jwtTokenProvider.getClaims(accessToken).get("memberId", Long.class);
         return memberId;
@@ -71,7 +67,7 @@ public class AuthService {
         if (accessTokenInHeader != null && accessTokenInHeader.startsWith("Bearer ")) {
             return accessTokenInHeader.substring(7);
         } else {
-            throw new IllegalArgumentException("Invalid token");
+            throw new InvalidTokenRequestException("JWT", accessTokenInHeader, "Invalid Bearer Format.");
         }
     }
 }

--- a/moa2/src/main/java/com/moa2/service/auth/RefreshTokenService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/RefreshTokenService.java
@@ -3,10 +3,8 @@ package com.moa2.service.auth;
 import com.moa2.repository.redis.RedisRepository;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 public class RefreshTokenService {
     private final RedisRepository redisRepository;
 

--- a/moa2/src/main/java/com/moa2/service/member/MemberService.java
+++ b/moa2/src/main/java/com/moa2/service/member/MemberService.java
@@ -30,7 +30,7 @@ public class MemberService {
     private void validateDuplicateMember(Member member) {
         memberRepository.findByEmail(member.getEmail())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("already exist email");
+                    throw new IllegalArgumentException("already exist email");
                 });
     }
 

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  security:
+    filter:
+      dispatcher-types: request
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/moa2?serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
+++ b/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
@@ -4,9 +4,11 @@ import com.moa2.domain.member.Member;
 import com.moa2.dto.auth.LoginDto;
 import com.moa2.dto.auth.SignupDto;
 import com.moa2.dto.auth.TokenDto;
+import com.moa2.exception.InvalidTokenRequestException;
 import com.moa2.repository.member.MemberRepository;
 import com.moa2.service.auth.AuthService;
 import com.moa2.service.member.MemberService;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +20,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -58,8 +61,7 @@ class JwtValidatorTest {
         loginDto.setEmail("test@example.com");
         loginDto.setPassword("password");
         TokenDto tokenDto = authService.login(loginDto);
-
-        assertThat(jwtValidator.validateToken(tokenDto.getAccessToken())).isTrue();
+        
         assertThat(jwtValidator.validateAccessToken(tokenDto.getAccessToken())).isTrue();
     }
 
@@ -72,7 +74,7 @@ class JwtValidatorTest {
 
         String badAccessToken = tokenDto.getAccessToken() + "bad";
 
-        assertThat(jwtValidator.validateToken(badAccessToken)).isFalse();
+        assertThrows(InvalidTokenRequestException.class, () -> jwtValidator.validateToken(badAccessToken));
     }
 
     @Test
@@ -84,7 +86,7 @@ class JwtValidatorTest {
         TokenDto tokenDto = authService.login(loginDto);
         authService.logout("Bearer " + tokenDto.getAccessToken());
 
-        assertThat(jwtValidator.validateAccessToken(tokenDto.getAccessToken())).isFalse();
+        assertThrows(InvalidTokenRequestException.class, () -> jwtValidator.validateAccessToken(tokenDto.getAccessToken()));
     }
 
     @Test
@@ -98,7 +100,7 @@ class JwtValidatorTest {
 
         String accessToken = jwtTokenProvider.createTokenWithSeconds(authentication, false, 0L);
 
-        assertThat(jwtValidator.validateToken(accessToken)).isFalse();
+        assertThrows(InvalidTokenRequestException.class, () -> jwtValidator.validateAccessToken(accessToken));
     }
 
     @Test
@@ -119,7 +121,7 @@ class JwtValidatorTest {
         TokenDto tokenDto = authService.login(loginDto);
         String badRefreshToken = tokenDto.getRefreshToken() + "bad";
 
-        assertThat(jwtValidator.validateRefreshToken(badRefreshToken)).isFalse();
+        assertThrows(InvalidTokenRequestException.class, () -> jwtValidator.validateRefreshToken(badRefreshToken));
     }
 
     @Test
@@ -130,7 +132,8 @@ class JwtValidatorTest {
         TokenDto tokenDto = authService.login(loginDto);
         authService.logout("Bearer " + tokenDto.getAccessToken());
 
-        assertThat(jwtValidator.validateRefreshToken(tokenDto.getRefreshToken())).isFalse();
+        assertThrows(InvalidTokenRequestException.class,
+                () -> jwtValidator.validateRefreshToken(tokenDto.getRefreshToken()));
     }
 
     @Test
@@ -143,7 +146,7 @@ class JwtValidatorTest {
 
         String refreshToken = jwtTokenProvider.createTokenWithSeconds(authentication, true, 0L);
 
-        assertThat(jwtValidator.validateRefreshToken(refreshToken)).isFalse();
+        assertThrows(InvalidTokenRequestException.class, () -> jwtValidator.validateRefreshToken(refreshToken));
     }
 
     @Test

--- a/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
+++ b/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
@@ -4,11 +4,10 @@ import com.moa2.domain.member.Member;
 import com.moa2.dto.auth.LoginDto;
 import com.moa2.dto.auth.SignupDto;
 import com.moa2.dto.auth.TokenDto;
-import com.moa2.exception.InvalidTokenRequestException;
+import com.moa2.exception.jwt.InvalidTokenRequestException;
 import com.moa2.repository.member.MemberRepository;
 import com.moa2.service.auth.AuthService;
 import com.moa2.service.member.MemberService;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +60,7 @@ class JwtValidatorTest {
         loginDto.setEmail("test@example.com");
         loginDto.setPassword("password");
         TokenDto tokenDto = authService.login(loginDto);
-        
+
         assertThat(jwtValidator.validateAccessToken(tokenDto.getAccessToken())).isTrue();
     }
 

--- a/moa2/src/test/java/com/moa2/service/member/MemberServiceTest.java
+++ b/moa2/src/test/java/com/moa2/service/member/MemberServiceTest.java
@@ -64,7 +64,7 @@ class MemberServiceTest {
 
         memberService.register(user);
 
-        assertThrows(IllegalStateException.class, () -> {
+        assertThrows(IllegalArgumentException.class, () -> {
             memberService.register(user);
         });
 


### PR DESCRIPTION
## ⭐Key Changes
1. GlobalExceptionHandler 를 만들어서 요청에서 발생하는 error 에 대해 제어하고 있는 것과 제어하고 있지 않은 것을 구분하였습니다. 이로 인해 controller 와 service 단에 존재했던 try catch 구문과 if 구문을 정리할 수 있었습니다.

2. 비인가 api에 대한 요청에 대한 에러가 403,401 이 동시에 발생하고 결국 마지막에 발생한 401 에러가 출력되는 오류를 해결했습니다.

## 📌 issue
close #이슈번호

## Next move
oauth 로그인 서비스를 구현하겠습니다.
