### PR TITLE
Feature/oauth

### DIFF
--- a/moa2/build.gradle
+++ b/moa2/build.gradle
@@ -25,6 +25,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	//oauth
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// jwt
 	implementation 'javax.xml.bind:jaxb-api'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/moa2/build.gradle
+++ b/moa2/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/moa2/src/main/java/com/moa2/config/RedisConfig.java
+++ b/moa2/src/main/java/com/moa2/config/RedisConfig.java
@@ -1,4 +1,4 @@
-package com.moa2.security.config;
+package com.moa2.config;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;

--- a/moa2/src/main/java/com/moa2/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/config/SecurityConfig.java
@@ -1,4 +1,4 @@
-package com.moa2.security.config;
+package com.moa2.config;
 
 import com.moa2.security.jwt.JwtFilter;
 import com.moa2.security.jwt.exception.JwtAccessDeniedHandler;
@@ -55,58 +55,58 @@ public class SecurityConfig {
 
 
         http
-                .csrf().disable()
+            .csrf().disable()
 
-                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
-                    .exceptionHandling()
-                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
-                        .accessDeniedHandler(jwtAccessDeniedHandler)
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling()
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                    .accessDeniedHandler(jwtAccessDeniedHandler)
 
-                // create no session
-                .and()
-                .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            // create no session
+            .and()
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
-                .and()
-                .authorizeHttpRequests()
-                    .requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN")
-                    .requestMatchers("/user/**").hasAuthority("ROLE_USER")
-                    .requestMatchers("/auth/**", "/oauth/**").permitAll()
-                    .requestMatchers("/",
-                            "/favicon.ico",
-                            "/**/*.json",
-                            "/**/*.xml",
-                            "/**/*.properties",
-                            "/**/*.woff2",
-                            "/**/*.woff",
-                            "/**/*.ttf",
-                            "/**/*.ttc",
-                            "/**/*.ico",
-                            "/**/*.bmp",
-                            "/**/*.png",
-                            "/**/*.gif",
-                            "/**/*.svg",
-                            "/**/*.jpg",
-                            "/**/*.jpeg",
-                            "/**/*.html",
-                            "/**/*.css",
-                            "/**/*.js").permitAll()
-                    .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .anyRequest().authenticated()
+            .and()
+            .authorizeHttpRequests()
+                .requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN")
+                .requestMatchers("/user/**").hasAuthority("ROLE_USER")
+                .requestMatchers("/auth/**", "/oauth/**").permitAll()
+                .requestMatchers("/",
+                        "/favicon.ico",
+                        "/**/*.json",
+                        "/**/*.xml",
+                        "/**/*.properties",
+                        "/**/*.woff2",
+                        "/**/*.woff",
+                        "/**/*.ttf",
+                        "/**/*.ttc",
+                        "/**/*.ico",
+                        "/**/*.bmp",
+                        "/**/*.png",
+                        "/**/*.gif",
+                        "/**/*.svg",
+                        "/**/*.jpg",
+                        "/**/*.jpeg",
+                        "/**/*.html",
+                        "/**/*.css",
+                        "/**/*.js").permitAll()
+                .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                .anyRequest().authenticated()
 
-                .and()
-                .oauth2Login()
-                    .authorizationEndpoint()
-                        .baseUri("/oauth2/authorize")
-                        .and()
-                    .redirectionEndpoint()
-                        .baseUri("/oauth2/callback/*")
-                        .and()
-                .userInfoEndpoint()
-                    .userService(customOAuth2UserService)
+            .and()
+            .oauth2Login()
+                .authorizationEndpoint()
+                    .baseUri("/oauth2/authorize")
                     .and()
-                .successHandler(oAuth2AuthenticationSuccessHandler)
-                .failureHandler(oAuth2AuthenticationFailureHandler);
+                .redirectionEndpoint()
+                    .baseUri("/oauth2/callback/*")
+                    .and()
+            .userInfoEndpoint()
+                .userService(customOAuth2UserService)
+                .and()
+            .successHandler(oAuth2AuthenticationSuccessHandler)
+            .failureHandler(oAuth2AuthenticationFailureHandler);
 
         return http.build();
     }

--- a/moa2/src/main/java/com/moa2/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/config/SecurityConfig.java
@@ -47,7 +47,7 @@ public class SecurityConfig {
                 config.setAllowedMethods(Collections.singletonList("*"));
                 config.setAllowedHeaders(Collections.singletonList("*"));
                 config.setAllowCredentials(true);
-                config.setExposedHeaders(List.of("Authorization")); // custom header 이므로 세팅에 추가
+                config.setExposedHeaders(List.of("Authorization")); // 사용할 header 이므로 추가
                 config.setMaxAge(3600L);
                 return config;
             }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -36,22 +36,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity login(@Valid @RequestBody LoginDto loginDto) {
         TokenDto tokenDto = authService.login(loginDto);
-
-        Long memberId = authService.getMemberIdInAccessToken(tokenDto.getAccessToken());
-        Long expirationTimeInAccessToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getAccessToken());
-        Long expirationTimeInRefreshToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getRefreshToken());
-
-        HttpCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
-                .path("/")
-                .maxAge(expirationTimeInRefreshToken)
-//                .secure(true)
-                .httpOnly(true)
-                .build();
-
-        return ResponseEntity
-                .status(HttpStatus.CREATED)
-                .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(new TokenResponseDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));
+        return CreateTokenDtoResponse(tokenDto);
     }
 
     @GetMapping("/logout")
@@ -70,7 +55,10 @@ public class AuthController {
     @GetMapping("/refresh")
     public ResponseEntity refresh(@CookieValue String refreshToken) {
         TokenDto tokenDto = authService.refresh(refreshToken);
+        return CreateTokenDtoResponse(tokenDto);
+    }
 
+    private ResponseEntity CreateTokenDtoResponse(TokenDto tokenDto) {
         Long memberId = authService.getMemberIdInAccessToken(tokenDto.getAccessToken());
         Long expirationTimeInAccessToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getAccessToken());
         Long expirationTimeInRefreshToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getRefreshToken());
@@ -85,5 +73,6 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(new TokenResponseDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));    }
+                .body(new TokenResponseDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));
+    }
 }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -13,7 +13,7 @@ import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 @Slf4j
 public class AuthController {

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -4,17 +4,14 @@ import com.moa2.domain.member.Member;
 import com.moa2.dto.auth.request.LoginDto;
 import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.dto.auth.TokenDto;
-import com.moa2.dto.auth.response.TokenResponseDto;
+import com.moa2.dto.auth.response.ResponseTokenDto;
 import com.moa2.service.auth.AuthService;
 import com.moa2.service.member.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
-import org.springframework.security.core.context.SecurityContext;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Date;
 
 @RestController
 @RequestMapping("/auth")
@@ -73,6 +70,6 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(new TokenResponseDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));
+                .body(new ResponseTokenDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));
     }
 }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -1,8 +1,8 @@
 package com.moa2.controller.auth;
 
 import com.moa2.domain.member.Member;
-import com.moa2.dto.auth.LoginDto;
-import com.moa2.dto.auth.SignupDto;
+import com.moa2.dto.auth.request.LoginDto;
+import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.dto.auth.TokenDto;
 import com.moa2.service.auth.AuthService;
 import com.moa2.service.member.MemberService;
@@ -11,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
 
 @RestController
 @RequestMapping("/auth")
@@ -35,6 +37,8 @@ public class AuthController {
                 // https 에서만 데이터를 보내므로 잠시 주석처리
 //                .secure(true)
                 .build();
+
+
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenDto.getAccessToken())

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -55,13 +55,6 @@ public class AuthController {
                 .body("logout success");
     }
 
-    @GetMapping("/mypage")
-    public ResponseEntity mypage(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberId(accessTokenInHeader);
-        String memberInfo = memberService.getMemberInfo(memberId);
-        return ResponseEntity.ok().body(memberInfo);
-    }
-
     @GetMapping("/refresh")
     public ResponseEntity refresh(@CookieValue String refreshToken) {
         TokenDto tokenDto = authService.refresh(refreshToken);
@@ -77,10 +70,5 @@ public class AuthController {
                 .body("refresh success");
     }
 
-    @GetMapping("/test-admin")
-    public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberId(accessTokenInHeader);
-        String memberInfo = memberService.getMemberInfo(memberId);
-        return ResponseEntity.ok().body(memberInfo);
-    }
+
 }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -57,12 +57,12 @@ public class AuthController {
 
     private ResponseEntity CreateTokenDtoResponse(TokenDto tokenDto) {
         Long memberId = authService.getMemberIdInAccessToken(tokenDto.getAccessToken());
-        Long expirationTimeInAccessToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getAccessToken());
-        Long expirationTimeInRefreshToken = authService.getExpirationTimeInMilliSeconds(tokenDto.getRefreshToken());
+        Long accessTokenExpirationInMilliSeconds = authService.getExpirationTimeInMilliSeconds(tokenDto.getAccessToken());
+        Long refreshTokenExpirationInSeconds = authService.getExpirationTimeInMilliSeconds(tokenDto.getRefreshToken());
 
         HttpCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
                 .path("/")
-                .maxAge(expirationTimeInRefreshToken)
+                .maxAge(refreshTokenExpirationInSeconds)
 //                .secure(true)
                 .httpOnly(true)
                 .build();
@@ -70,6 +70,6 @@ public class AuthController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(new ResponseTokenDto(tokenDto.getAccessToken(), memberId, expirationTimeInAccessToken));
+                .body(new ResponseTokenDto(tokenDto.getAccessToken(), memberId, accessTokenExpirationInMilliSeconds));
     }
 }

--- a/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
+++ b/moa2/src/main/java/com/moa2/controller/auth/AuthController.java
@@ -48,8 +48,6 @@ public class AuthController {
                 .httpOnly(true)
                 .build();
 
-
-
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())

--- a/moa2/src/main/java/com/moa2/controller/member/AdminController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/AdminController.java
@@ -20,7 +20,7 @@ public class AdminController {
 
     @GetMapping("/test-admin")
     public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberIdInAccessToken(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInAccessTokenInBearer(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/controller/member/AdminController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/AdminController.java
@@ -20,7 +20,7 @@ public class AdminController {
 
     @GetMapping("/test-admin")
     public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberIdInAccessTokenInBearer(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInBearerAccessToken(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/controller/member/AdminController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/AdminController.java
@@ -1,0 +1,27 @@
+package com.moa2.controller.member;
+
+import com.moa2.service.auth.AuthService;
+import com.moa2.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/admin")
+@RequiredArgsConstructor
+@Slf4j
+public class AdminController {
+    private final AuthService authService;
+    private final MemberService memberService;
+
+    @GetMapping("/test-admin")
+    public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
+        Long memberId = authService.getMemberId(accessTokenInHeader);
+        String memberInfo = memberService.getMemberInfo(memberId);
+        return ResponseEntity.ok().body(memberInfo);
+    }
+}

--- a/moa2/src/main/java/com/moa2/controller/member/AdminController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/AdminController.java
@@ -20,7 +20,7 @@ public class AdminController {
 
     @GetMapping("/test-admin")
     public ResponseEntity testAdmin(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberId(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInAccessToken(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/controller/member/AdminController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/AdminController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/admin")
+@RequestMapping("/admin")
 @RequiredArgsConstructor
 @Slf4j
 public class AdminController {

--- a/moa2/src/main/java/com/moa2/controller/member/UserController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/UserController.java
@@ -1,0 +1,28 @@
+package com.moa2.controller.member;
+
+import com.moa2.service.auth.AuthService;
+import com.moa2.service.member.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("api/user")
+@RequiredArgsConstructor
+@Slf4j
+public class UserController {
+    private final AuthService authService;
+    private final MemberService memberService;
+    @GetMapping("/mypage")
+    public ResponseEntity mypage(@RequestHeader("Authorization") String accessTokenInHeader) {
+        Long memberId = authService.getMemberId(accessTokenInHeader);
+        String memberInfo = memberService.getMemberInfo(memberId);
+        return ResponseEntity.ok().body(memberInfo);
+    }
+
+
+}

--- a/moa2/src/main/java/com/moa2/controller/member/UserController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
     private final MemberService memberService;
     @GetMapping("/mypage")
     public ResponseEntity mypage(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberIdInAccessTokenInBearer(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInBearerAccessToken(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/controller/member/UserController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/UserController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("api/user")
+@RequestMapping("/user")
 @RequiredArgsConstructor
 @Slf4j
 public class UserController {

--- a/moa2/src/main/java/com/moa2/controller/member/UserController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
     private final MemberService memberService;
     @GetMapping("/mypage")
     public ResponseEntity mypage(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberIdInAccessToken(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInAccessTokenInBearer(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/controller/member/UserController.java
+++ b/moa2/src/main/java/com/moa2/controller/member/UserController.java
@@ -19,7 +19,7 @@ public class UserController {
     private final MemberService memberService;
     @GetMapping("/mypage")
     public ResponseEntity mypage(@RequestHeader("Authorization") String accessTokenInHeader) {
-        Long memberId = authService.getMemberId(accessTokenInHeader);
+        Long memberId = authService.getMemberIdInAccessToken(accessTokenInHeader);
         String memberInfo = memberService.getMemberInfo(memberId);
         return ResponseEntity.ok().body(memberInfo);
     }

--- a/moa2/src/main/java/com/moa2/domain/member/Member.java
+++ b/moa2/src/main/java/com/moa2/domain/member/Member.java
@@ -1,6 +1,10 @@
 package com.moa2.domain.member;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.moa2.security.oauth2.AuthProvider;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -15,12 +19,26 @@ public class Member {
     @Column(name = "member_id")
     private Long id;
 
+//    @Column(nullable = false)
     private String nickname;
 
+//    @Email
     @Column(unique = true)
     private String email;
 
+    @JsonIgnore
     private String password;
+
+    private String imageUrl;
+
+//    @Column(nullable = false)
+//    private Boolean emailVerified = false;
+
+//    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
+    private String providerId;
+
 
     @ManyToMany
     @JoinTable(name = "member_authority",

--- a/moa2/src/main/java/com/moa2/dto/auth/request/LoginDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/request/LoginDto.java
@@ -1,4 +1,4 @@
-package com.moa2.dto.auth;
+package com.moa2.dto.auth.request;
 
 import lombok.Data;
 

--- a/moa2/src/main/java/com/moa2/dto/auth/request/SignupDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/request/SignupDto.java
@@ -1,4 +1,4 @@
-package com.moa2.dto.auth;
+package com.moa2.dto.auth.request;
 
 import lombok.Data;
 

--- a/moa2/src/main/java/com/moa2/dto/auth/response/ResponseTokenDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/response/ResponseTokenDto.java
@@ -3,12 +3,12 @@ package com.moa2.dto.auth.response;
 import lombok.Data;
 
 @Data
-public class TokenResponseDto {
+public class ResponseTokenDto {
     String accessToken;
     Long memberId;
     Long expirationTimeInMilliSeconds;
 
-    public TokenResponseDto(String accessToken, Long memberId, Long expirationTimeInMilliSeconds) {
+    public ResponseTokenDto(String accessToken, Long memberId, Long expirationTimeInMilliSeconds) {
         this.accessToken = accessToken;
         this.memberId = memberId;
         this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;

--- a/moa2/src/main/java/com/moa2/dto/auth/response/ResponseTokenDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/response/ResponseTokenDto.java
@@ -6,11 +6,11 @@ import lombok.Data;
 public class ResponseTokenDto {
     String accessToken;
     Long memberId;
-    Long expirationTimeInMilliSeconds;
+    Long accessTokenExpirationInMilliSeconds;
 
-    public ResponseTokenDto(String accessToken, Long memberId, Long expirationTimeInMilliSeconds) {
+    public ResponseTokenDto(String accessToken, Long memberId, Long accessTokenExpirationInMilliSeconds) {
         this.accessToken = accessToken;
         this.memberId = memberId;
-        this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;
+        this.accessTokenExpirationInMilliSeconds = accessTokenExpirationInMilliSeconds;
     }
 }

--- a/moa2/src/main/java/com/moa2/dto/auth/response/TokenResponseDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/response/TokenResponseDto.java
@@ -1,5 +1,16 @@
 package com.moa2.dto.auth.response;
 
+import lombok.Data;
+
+@Data
 public class TokenResponseDto {
     String accessToken;
+    Long memberId;
+    Long expirationTimeInMilliSeconds;
+
+    public TokenResponseDto(String accessToken, Long memberId, Long expirationTimeInMilliSeconds) {
+        this.accessToken = accessToken;
+        this.memberId = memberId;
+        this.expirationTimeInMilliSeconds = expirationTimeInMilliSeconds;
+    }
 }

--- a/moa2/src/main/java/com/moa2/dto/auth/response/TokenResponseDto.java
+++ b/moa2/src/main/java/com/moa2/dto/auth/response/TokenResponseDto.java
@@ -1,0 +1,5 @@
+package com.moa2.dto.auth.response;
+
+public class TokenResponseDto {
+    String accessToken;
+}

--- a/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
+++ b/moa2/src/main/java/com/moa2/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.moa2.exception;
 
 import com.moa2.exception.jwt.InvalidTokenRequestException;
+import com.moa2.exception.oauth.OAuth2AuthenticationProcessingException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -14,14 +15,17 @@ public class GlobalExceptionHandler {
     // 400
     @ExceptionHandler(IllegalArgumentException.class)
     @ResponseBody
-    public ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex) {
+    public ResponseEntity<Object> handleBadRequestException(Exception ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     // 401
-    @ExceptionHandler({InvalidTokenRequestException.class, BadCredentialsException.class})
+    @ExceptionHandler({
+            InvalidTokenRequestException.class,
+            BadCredentialsException.class,
+            OAuth2AuthenticationProcessingException.class})
     @ResponseBody
-    public ResponseEntity<Object> handleIllegalArgumentException(InvalidTokenRequestException ex) {
+    public ResponseEntity<Object> handleUnAuthorizedException(Exception ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.UNAUTHORIZED);
     }
 

--- a/moa2/src/main/java/com/moa2/exception/oauth/OAuth2AuthenticationProcessingException.java
+++ b/moa2/src/main/java/com/moa2/exception/oauth/OAuth2AuthenticationProcessingException.java
@@ -1,0 +1,13 @@
+package com.moa2.exception.oauth;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2AuthenticationProcessingException extends AuthenticationException {
+    public OAuth2AuthenticationProcessingException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public OAuth2AuthenticationProcessingException(String msg) {
+        super(msg);
+    }
+}

--- a/moa2/src/main/java/com/moa2/repository/member/MemberRepository.java
+++ b/moa2/src/main/java/com/moa2/repository/member/MemberRepository.java
@@ -2,6 +2,8 @@ package com.moa2.repository.member;
 
 import com.moa2.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -9,4 +11,8 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
+
+    @Query("SELECT m FROM Member m JOIN FETCH m.authorities WHERE m.email = :email")
+    Optional<Member> findByEmailEagerly(@Param("email") String email);
 }

--- a/moa2/src/main/java/com/moa2/repository/member/MemberRepository.java
+++ b/moa2/src/main/java/com/moa2/repository/member/MemberRepository.java
@@ -12,7 +12,6 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
 
-
     @Query("SELECT m FROM Member m JOIN FETCH m.authorities WHERE m.email = :email")
-    Optional<Member> findByEmailEagerly(@Param("email") String email);
+    Optional<Member> findByEmailEagerlyAuthorities(@Param("email") String email);
 }

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 @EnableWebSecurity
 @Configuration
@@ -45,7 +46,7 @@ public class SecurityConfig {
                 config.setAllowedMethods(Collections.singletonList("*"));
                 config.setAllowedHeaders(Collections.singletonList("*"));
                 config.setAllowCredentials(true);
-                config.setExposedHeaders(Arrays.asList("Authorization")); // custom header 이므로 세팅에 추가
+                config.setExposedHeaders(List.of("Authorization")); // custom header 이므로 세팅에 추가
                 config.setMaxAge(3600L);
                 return config;
             }
@@ -72,6 +73,25 @@ public class SecurityConfig {
                     .requestMatchers("admin/**").hasAuthority("ROLE_ADMIN")
                     .requestMatchers("user/**").hasAuthority("ROLE_USER")
                     .requestMatchers("auth/**", "oauth/**", "logout", "/").permitAll()
+                    .requestMatchers("/",
+                            "/favicon.ico",
+                            "/**/*.json",
+                            "/**/*.xml",
+                            "/**/*.properties",
+                            "/**/*.woff2",
+                            "/**/*.woff",
+                            "/**/*.ttf",
+                            "/**/*.ttc",
+                            "/**/*.ico",
+                            "/**/*.bmp",
+                            "/**/*.png",
+                            "/**/*.gif",
+                            "/**/*.svg",
+                            "/**/*.jpg",
+                            "/**/*.jpeg",
+                            "/**/*.html",
+                            "/**/*.css",
+                            "/**/*.js").permitAll()
                     .anyRequest().authenticated()
 
                 .and()

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -65,11 +65,17 @@ public class SecurityConfig {
                 .authorizeHttpRequests()
                 .requestMatchers("admin/**").hasAuthority("ROLE_ADMIN")
                 .requestMatchers("user/**").hasAuthority("ROLE_USER")
-                .requestMatchers("auth/**").permitAll()
+                .requestMatchers("auth/**", "oauth/**").permitAll()
                 .anyRequest().authenticated()
 
                 .and()
-                .oauth2Login();
+                .oauth2Login()
+                    .authorizationEndpoint()
+                        .baseUri("/oauth2/authorize")
+                        .and()
+                    .redirectionEndpoint()
+                        .baseUri("/oauth2/callback/*")
+                        .and();
 
 
         return http.build();

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -63,9 +63,9 @@ public class SecurityConfig {
 
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers("api/admin/**").hasAuthority("ROLE_ADMIN")
-                .requestMatchers("api/user/**").hasAuthority("ROLE_USER")
-                .requestMatchers("api/auth/**").permitAll()
+                .requestMatchers("admin/**").hasAuthority("ROLE_ADMIN")
+                .requestMatchers("user/**").hasAuthority("ROLE_USER")
+                .requestMatchers("auth/**").permitAll()
                 .anyRequest().authenticated()
 
                 .and()

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -14,6 +14,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -55,8 +56,6 @@ public class SecurityConfig {
 
         http
                 .csrf().disable()
-                .httpBasic().disable()
-                .formLogin().disable()
 
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                     .exceptionHandling()
@@ -70,9 +69,9 @@ public class SecurityConfig {
 
                 .and()
                 .authorizeHttpRequests()
-                    .requestMatchers("admin/**").hasAuthority("ROLE_ADMIN")
-                    .requestMatchers("user/**").hasAuthority("ROLE_USER")
-                    .requestMatchers("auth/**", "oauth/**", "logout", "/").permitAll()
+                    .requestMatchers("/admin/**").hasAuthority("ROLE_ADMIN")
+                    .requestMatchers("/user/**").hasAuthority("ROLE_USER")
+                    .requestMatchers("/auth/**", "/oauth/**").permitAll()
                     .requestMatchers("/",
                             "/favicon.ico",
                             "/**/*.json",
@@ -92,6 +91,7 @@ public class SecurityConfig {
                             "/**/*.html",
                             "/**/*.css",
                             "/**/*.js").permitAll()
+                    .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
                     .anyRequest().authenticated()
 
                 .and()
@@ -120,5 +120,10 @@ public class SecurityConfig {
     AuthenticationManager authenticationManager(AuthenticationConfiguration authenticationConfiguration)
             throws Exception {
         return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public WebSecurityCustomizer webSecurityCustomizer() {
+        return (web) -> web.ignoring().requestMatchers( "/swagger-ui/**", "/v3/api-docs/**");
     }
 }

--- a/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
+++ b/moa2/src/main/java/com/moa2/security/config/SecurityConfig.java
@@ -63,10 +63,14 @@ public class SecurityConfig {
 
                 .and()
                 .authorizeHttpRequests()
-                .requestMatchers("api/auth/test-admin").hasAuthority("ROLE_ADMIN")
-                .requestMatchers("api/auth/mypage").hasAuthority("ROLE_USER")
-                .requestMatchers("api/auth/register", "api/auth/login", "api/auth/refresh").permitAll()
-                .anyRequest().authenticated();
+                .requestMatchers("api/admin/**").hasAuthority("ROLE_ADMIN")
+                .requestMatchers("api/user/**").hasAuthority("ROLE_USER")
+                .requestMatchers("api/auth/**").permitAll()
+                .anyRequest().authenticated()
+
+                .and()
+                .oauth2Login();
+
 
         return http.build();
     }

--- a/moa2/src/main/java/com/moa2/security/jwt/JwtTokenProvider.java
+++ b/moa2/src/main/java/com/moa2/security/jwt/JwtTokenProvider.java
@@ -37,9 +37,9 @@ public class JwtTokenProvider implements InitializingBean {
     private final MemberRepository memberRepository;
 
     public JwtTokenProvider(
-            @Value("${jwt.secret}") String secret, // hmac 암호화를 사용하므로 32bit 를 넘어야한다.
-            @Value("${jwt.access-token-validity-in-seconds}") long tokenValidTime,
-            @Value("${jwt.refresh-token-validity-in-seconds}") long refreshTokenValidTime,
+            @Value("${app.jwt.secret}") String secret, // hmac 암호화를 사용하므로 32bit 를 넘어야한다.
+            @Value("${app.jwt.access-token-validity-in-seconds}") long tokenValidTime,
+            @Value("${app.jwt.refresh-token-validity-in-seconds}") long refreshTokenValidTime,
             RefreshTokenService refreshTokenService,
             AccessTokenService accessTokenService,
             MemberRepository memberRepository) {

--- a/moa2/src/main/java/com/moa2/security/oauth2/AuthProvider.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/AuthProvider.java
@@ -1,0 +1,8 @@
+package com.moa2.security.oauth2;
+
+public enum AuthProvider {
+    local,
+    naver,
+    google,
+    github
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
@@ -51,7 +51,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
         }
 
-        Optional<Member> memberOptional = memberRepository.findByEmail(oAuth2UserInfo.getEmail());
+        Optional<Member> memberOptional = memberRepository.findByEmailEagerly(oAuth2UserInfo.getEmail());
         Member member;
 
         if (memberOptional.isPresent()) {

--- a/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,91 @@
+package com.moa2.security.oauth2;
+
+import com.moa2.domain.member.Member;
+import com.moa2.exception.oauth.OAuth2AuthenticationProcessingException;
+import com.moa2.repository.member.AuthorityRepository;
+import com.moa2.repository.member.MemberRepository;
+import com.moa2.security.oauth2.user.OAuth2UserInfo;
+import com.moa2.security.oauth2.user.OAuth2UserInfoFactory;
+import com.moa2.security.userdetails.MemberDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.security.sasl.AuthenticationException;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final MemberRepository memberRepository;
+    private final AuthorityRepository authorityRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        try {
+            return processOAuth2User(userRequest, oAuth2User);
+        } catch (Exception ex) {
+            // Throwing an instance of AuthenticationException will trigger the OAuth2AuthenticationFailureHandler
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(
+                userRequest.getClientRegistration().getRegistrationId(),
+                oAuth2User.getAttributes()
+        );
+
+        String email = oAuth2UserInfo.getEmail();
+        if (email.isEmpty()) {
+            throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
+        }
+
+        Optional<Member> memberOptional = memberRepository.findByEmail(oAuth2UserInfo.getEmail());
+        Member member;
+
+        if (memberOptional.isPresent()) {
+            member = memberOptional.get();
+            if (!member.getProvider().equals(AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId()))) {
+                throw new OAuth2AuthenticationProcessingException("Looks like you're signed up with " +
+                        member.getProvider() + " account. Please use your " + member.getProvider() +
+                        " account to login.");
+            }
+            member = updateExistingUser(member, oAuth2UserInfo);
+        } else {
+            member = registerNewUser(userRequest, oAuth2UserInfo);
+        }
+
+        return MemberDetails.createWithAttributes(member, oAuth2User.getAttributes());
+    }
+
+    private Member registerNewUser(OAuth2UserRequest userRequest, OAuth2UserInfo oAuth2UserInfo) {
+        Member member = new Member();
+
+        member.setProvider(AuthProvider.valueOf(userRequest.getClientRegistration().getRegistrationId()));
+        member.setProviderId(oAuth2UserInfo.getId());
+        member.setNickname(oAuth2UserInfo.getName());
+        member.setEmail(oAuth2UserInfo.getEmail());
+        member.setImageUrl(oAuth2UserInfo.getImageUrl());
+        member.getAuthorities().add(authorityRepository.findByName("ROLE_USER"));
+
+        return memberRepository.save(member);
+    }
+
+
+    private Member updateExistingUser(Member existingMember, OAuth2UserInfo oAuth2UserInfo) {
+        existingMember.setNickname(oAuth2UserInfo.getName());
+        existingMember.setImageUrl(oAuth2UserInfo.getImageUrl());
+        return memberRepository.save(existingMember);
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/CustomOAuth2UserService.java
@@ -16,7 +16,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.security.sasl.AuthenticationException;
 import java.util.Optional;
 
 @Service
@@ -51,7 +50,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
         }
 
-        Optional<Member> memberOptional = memberRepository.findByEmailEagerly(oAuth2UserInfo.getEmail());
+        Optional<Member> memberOptional = memberRepository.findByEmailEagerlyAuthorities(oAuth2UserInfo.getEmail());
         Member member;
 
         if (memberOptional.isPresent()) {

--- a/moa2/src/main/java/com/moa2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,2 +1,53 @@
-package com.moa2.security.oauth2;public class HttpCookieOAuth2AuthorizationRequestRepository {
+package com.moa2.security.oauth2;
+
+import com.moa2.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+                CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                 HttpServletResponse response) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
 }

--- a/moa2/src/main/java/com/moa2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,2 @@
+package com.moa2.security.oauth2;public class HttpCookieOAuth2AuthorizationRequestRepository {
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -24,16 +24,8 @@ public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationF
     public void onAuthenticationFailure(HttpServletRequest request,
                                         HttpServletResponse response, AuthenticationException exception)
             throws IOException, ServletException {
-        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
-                .map(Cookie::getValue)
-                .orElse(("/"));
-
-        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("error", exception.getLocalizedMessage())
-                .build().toUriString();
-
         httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
 
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, exception.getMessage());
     }
 }

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package com.moa2.security.oauth2;
+
+import com.moa2.util.CookieUtils;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+import static com.moa2.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response, AuthenticationException exception)
+            throws IOException, ServletException {
+        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(("/"));
+
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -44,12 +44,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         TokenDto tokenDto = jwtTokenProvider.createTokens(authentication);
 
         Long memberId = jwtTokenProvider.getClaims(tokenDto.getAccessToken()).get("memberId", Long.class);
-        Long expirationTimeInAccessToken = jwtTokenProvider.getClaims(tokenDto.getAccessToken()).getExpiration().getTime();
-        Long expirationTimeInRefreshToken = jwtTokenProvider.getClaims(tokenDto.getRefreshToken()).getExpiration().getTime();
+        Long accessTokenExpirationInMilliSeconds =
+                jwtTokenProvider.getClaims(tokenDto.getAccessToken()).getExpiration().getTime();
+        Long refreshTokenExpirationInSeconds =
+                jwtTokenProvider.getClaims(tokenDto.getRefreshToken()).getExpiration().getTime()/1000;
 
         HttpCookie cookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
                 .path("/")
-                .maxAge(expirationTimeInRefreshToken)
+                .maxAge(refreshTokenExpirationInSeconds)
 //                .secure(true)
                 .httpOnly(true)
                 .build();
@@ -59,7 +61,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         ResponseTokenDto responseTokenDto = new ResponseTokenDto(
                 tokenDto.getAccessToken(),
                 memberId,
-                expirationTimeInAccessToken
+                accessTokenExpirationInMilliSeconds
         );
 
         ObjectMapper objectMapper = new ObjectMapper();

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
@@ -64,6 +65,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         ObjectMapper objectMapper = new ObjectMapper();
         String jsonString = objectMapper.writeValueAsString(responseTokenDto);
 
+        response.setStatus(HttpStatus.CREATED.value());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(jsonString);

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -3,10 +3,14 @@ package com.moa2.security.oauth2;
 import com.moa2.dto.auth.TokenDto;
 import com.moa2.security.jwt.JwtTokenProvider;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpCookie;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -26,7 +30,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
             throws IOException, ServletException {
         String targetUrl = determineTargetUrl(request, response, authentication);
 
-
         if (response.isCommitted()) {
             log.debug("Response has already been committed. Unable to redirect to ");
             return;
@@ -36,10 +39,14 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         TokenDto tokenDto = jwtTokenProvider.createTokens(authentication);
         response.setHeader("Authorization", "Bearer " + tokenDto.getAccessToken());
 
+        HttpCookie httpCookie = ResponseCookie.from("refreshToken", tokenDto.getRefreshToken())
+                .httpOnly(true)
+//                .secure(true)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, httpCookie.toString());
 
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
-
-
 
     protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
         super.clearAuthenticationAttributes(request);

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,48 @@
+package com.moa2.security.oauth2;
+
+import com.moa2.dto.auth.TokenDto;
+import com.moa2.security.jwt.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request,
+                                        HttpServletResponse response, Authentication authentication)
+            throws IOException, ServletException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+
+        if (response.isCommitted()) {
+            log.debug("Response has already been committed. Unable to redirect to ");
+            return;
+        }
+        clearAuthenticationAttributes(request, response);
+
+        TokenDto tokenDto = jwtTokenProvider.createTokens(authentication);
+        response.setHeader("Authorization", "Bearer " + tokenDto.getAccessToken());
+
+
+    }
+
+
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -2,6 +2,7 @@ package com.moa2.security.oauth2;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moa2.dto.auth.TokenDto;
+import com.moa2.dto.auth.response.ResponseTokenDto;
 import com.moa2.security.jwt.JwtTokenProvider;
 import com.moa2.service.auth.AuthService;
 import jakarta.servlet.ServletException;
@@ -32,7 +33,6 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response, Authentication authentication)
             throws IOException, ServletException {
-        String targetUrl = determineTargetUrl(request, response, authentication);
 
         if (response.isCommitted()) {
             log.debug("Response has already been committed. Unable to redirect to ");
@@ -54,19 +54,21 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
-        Map<String, Object> jsonData = new HashMap<>();
 
-        jsonData.put("accessToken", tokenDto.getAccessToken());
-        jsonData.put("memberId", memberId.toString());
-        jsonData.put("expirationTimeInAccessToken", expirationTimeInAccessToken);
+        ResponseTokenDto responseTokenDto = new ResponseTokenDto(
+                tokenDto.getAccessToken(),
+                memberId,
+                expirationTimeInAccessToken
+        );
 
         ObjectMapper objectMapper = new ObjectMapper();
-        String jsonString = objectMapper.writeValueAsString(jsonData);
+        String jsonString = objectMapper.writeValueAsString(responseTokenDto);
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(jsonString);
         response.getWriter().flush();
+        response.getWriter().close();
     }
 
     protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/GithubOAuth2UserInfo.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/GithubOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package com.moa2.security.oauth2.user;
+
+import java.util.Map;
+
+public class GithubOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GithubOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return ((Integer) attributes.get("id")).toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("avatar_url");
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/GoogleOAuth2UserInfo.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/GoogleOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package com.moa2.security.oauth2.user;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/NaverOAuth2UserInfo.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/NaverOAuth2UserInfo.java
@@ -4,12 +4,12 @@ import java.util.Map;
 
 public class NaverOAuth2UserInfo extends OAuth2UserInfo{
     public NaverOAuth2UserInfo(Map<String, Object> attributes) {
-        super(attributes);
+        super((Map<String, Object>) attributes.get("response"));
     }
 
     @Override
     public String getId() {
-        return ((Integer) attributes.get("id")).toString();
+        return (String) attributes.get("id");
     }
 
     @Override
@@ -24,6 +24,6 @@ public class NaverOAuth2UserInfo extends OAuth2UserInfo{
 
     @Override
     public String getImageUrl() {
-        return (String) attributes.get("avatar_url");
+        return (String) attributes.get("profile_image");
     }
 }

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/NaverOAuth2UserInfo.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/NaverOAuth2UserInfo.java
@@ -1,0 +1,29 @@
+package com.moa2.security.oauth2.user;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo extends OAuth2UserInfo{
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return ((Integer) attributes.get("id")).toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("avatar_url");
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfo.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.moa2.security.oauth2.user;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,16 @@
+package com.moa2.security.oauth2.user;
+
+import com.moa2.exception.oauth.OAuth2AuthenticationProcessingException;
+import com.moa2.security.oauth2.AuthProvider;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if(registrationId.equalsIgnoreCase(AuthProvider.github.toString())) {
+            return new GithubOAuth2UserInfo(attributes);
+        } else {
+            throw new OAuth2AuthenticationProcessingException("Sorry! Login with " + registrationId + " is not supported yet.");
+        }
+    }
+}

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -11,6 +11,8 @@ public class OAuth2UserInfoFactory {
             return new GithubOAuth2UserInfo(attributes);
         }else if (registrationId.equalsIgnoreCase(AuthProvider.google.toString())) {
             return new GoogleOAuth2UserInfo(attributes);
+        }else if (registrationId.equalsIgnoreCase(AuthProvider.naver.toString())) {
+            return new NaverOAuth2UserInfo(attributes);
         }else {
             throw new OAuth2AuthenticationProcessingException("Sorry! Login with " + registrationId + " is not supported yet.");
         }

--- a/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/moa2/src/main/java/com/moa2/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -9,7 +9,9 @@ public class OAuth2UserInfoFactory {
     public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
         if(registrationId.equalsIgnoreCase(AuthProvider.github.toString())) {
             return new GithubOAuth2UserInfo(attributes);
-        } else {
+        }else if (registrationId.equalsIgnoreCase(AuthProvider.google.toString())) {
+            return new GoogleOAuth2UserInfo(attributes);
+        }else {
             throw new OAuth2AuthenticationProcessingException("Sorry! Login with " + registrationId + " is not supported yet.");
         }
     }

--- a/moa2/src/main/java/com/moa2/security/userdetails/MemberDetails.java
+++ b/moa2/src/main/java/com/moa2/security/userdetails/MemberDetails.java
@@ -34,6 +34,12 @@ public class MemberDetails implements OAuth2User, UserDetails {
         this.attributes = attributes;
     }
 
+    public static MemberDetails createWithAttributes(Member member, Map<String, Object> attributes) {
+        MemberDetails memberDetails = new MemberDetails(member);
+        memberDetails.setAttributes(attributes);
+        return memberDetails;
+    }
+
     // UserDetails
 
     @Override

--- a/moa2/src/main/java/com/moa2/security/userdetails/MemberDetails.java
+++ b/moa2/src/main/java/com/moa2/security/userdetails/MemberDetails.java
@@ -5,17 +5,36 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
-public class MemberDetails implements UserDetails {
+public class MemberDetails implements OAuth2User, UserDetails {
     private final Member member;
+    private Map<String, Object> attributes;
 
     public Long getMemberId() {
         return member.getId();
     }
+
+    // OAuth2User
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    // UserDetails
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -53,4 +72,6 @@ public class MemberDetails implements UserDetails {
     public boolean isEnabled() {
         return true;
     }
+
+
 }

--- a/moa2/src/main/java/com/moa2/service/auth/AccessTokenService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AccessTokenService.java
@@ -10,7 +10,7 @@ public class AccessTokenService {
     private final long accessTokenValidityInSeconds;
 
     public AccessTokenService(RedisRepository redisRepository,
-                              @Value("${jwt.access-token-validity-in-seconds}")
+                              @Value("${app.jwt.access-token-validity-in-seconds}")
                               long accessTokenValidityInSeconds) {
         this.redisRepository = redisRepository;
         this.accessTokenValidityInSeconds = accessTokenValidityInSeconds;

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -47,17 +47,18 @@ public class AuthService {
     public TokenDto refresh(String refreshToken) {
         jwtValidator.validateRefreshToken(refreshToken);
 
-        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
-
         String accessToken = refreshTokenService.getRefreshToken(refreshToken);
         accessTokenService.deleteAccessToken(accessToken);
         refreshTokenService.deleteRefreshToken(refreshToken);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
         return jwtTokenProvider.createTokens(authentication);
     }
 
 
     public Long getMemberId(String accessTokenInHeader) {
         jwtValidator.validateAccessToken(resolveToken(accessTokenInHeader));
+
         String accessToken = resolveToken(accessTokenInHeader);
         Long memberId = jwtTokenProvider.getClaims(accessToken).get("memberId", Long.class);
         return memberId;

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -56,7 +56,7 @@ public class AuthService {
     }
 
 
-    public Long getMemberIdInAccessTokenInBearer(String accessTokenInBearer) {
+    public Long getMemberIdInBearerAccessToken(String accessTokenInBearer) {
         String accessToken = resolveToken(accessTokenInBearer);
         return getMemberIdInAccessToken(accessToken);
     }

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -56,13 +56,17 @@ public class AuthService {
     }
 
 
-    public Long getMemberIdInAccessToken(String accessTokenInHeader) {
-        jwtValidator.validateAccessToken(resolveToken(accessTokenInHeader));
-
-        String accessToken = resolveToken(accessTokenInHeader);
-        Long memberId = jwtTokenProvider.getClaims(accessToken).get("memberId", Long.class);
-        return memberId;
+    public Long getMemberIdInAccessTokenInBearer(String accessTokenInBearer) {
+        String accessToken = resolveToken(accessTokenInBearer);
+        return getMemberIdInAccessToken(accessToken);
     }
+
+    public Long getMemberIdInAccessToken(String accessToken) {
+        jwtValidator.validateAccessToken(accessToken);
+        return jwtTokenProvider.getClaims(accessToken).get("memberId", Long.class);
+    }
+
+
 
     public Long getExpirationTimeInMilliSeconds(String jwt) {
         jwtValidator.validateToken(jwt);

--- a/moa2/src/main/java/com/moa2/service/auth/AuthService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/AuthService.java
@@ -1,6 +1,6 @@
 package com.moa2.service.auth;
 
-import com.moa2.dto.auth.LoginDto;
+import com.moa2.dto.auth.request.LoginDto;
 import com.moa2.exception.jwt.InvalidTokenRequestException;
 import com.moa2.security.jwt.JwtTokenProvider;
 import com.moa2.security.jwt.JwtValidator;
@@ -56,12 +56,17 @@ public class AuthService {
     }
 
 
-    public Long getMemberId(String accessTokenInHeader) {
+    public Long getMemberIdInAccessToken(String accessTokenInHeader) {
         jwtValidator.validateAccessToken(resolveToken(accessTokenInHeader));
 
         String accessToken = resolveToken(accessTokenInHeader);
         Long memberId = jwtTokenProvider.getClaims(accessToken).get("memberId", Long.class);
         return memberId;
+    }
+
+    public Long getExpirationTimeInMilliSeconds(String jwt) {
+        jwtValidator.validateToken(jwt);
+        return jwtTokenProvider.getClaims(jwt).getExpiration().getTime();
     }
 
     private String resolveToken(String accessTokenInHeader) {

--- a/moa2/src/main/java/com/moa2/service/auth/RefreshTokenService.java
+++ b/moa2/src/main/java/com/moa2/service/auth/RefreshTokenService.java
@@ -11,7 +11,7 @@ public class RefreshTokenService {
     private final long refreshTokenValidityInSeconds;
 
     public RefreshTokenService(RedisRepository redisRepository,
-                               @Value("${jwt.refresh-token-validity-in-seconds}")
+                               @Value("${app.jwt.refresh-token-validity-in-seconds}")
                                long refreshTokenValidityInSeconds) {
         this.redisRepository = redisRepository;
         this.refreshTokenValidityInSeconds = refreshTokenValidityInSeconds;

--- a/moa2/src/main/java/com/moa2/service/member/MemberService.java
+++ b/moa2/src/main/java/com/moa2/service/member/MemberService.java
@@ -1,7 +1,7 @@
 package com.moa2.service.member;
 
 import com.moa2.domain.member.Member;
-import com.moa2.dto.auth.SignupDto;
+import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.repository.member.AuthorityRepository;
 import com.moa2.repository.member.MemberRepository;
 import jakarta.validation.Valid;

--- a/moa2/src/main/java/com/moa2/util/CookieUtils.java
+++ b/moa2/src/main/java/com/moa2/util/CookieUtils.java
@@ -1,0 +1,2 @@
+package com.moa2.util;public class CookieUtils {
+}

--- a/moa2/src/main/java/com/moa2/util/CookieUtils.java
+++ b/moa2/src/main/java/com/moa2/util/CookieUtils.java
@@ -1,2 +1,60 @@
-package com.moa2.util;public class CookieUtils {
+package com.moa2.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.util.SerializationUtils;
+
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+
+
 }

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -13,12 +13,28 @@ spring:
               - user:email
               - read:user
           google :
-            client-id: 152773267174-t42hi5dpk4pulm7ljssnf331itoipgck.apps.googleusercontent.com
-            client-secret: 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
+            client-id: 152773267174-q79s8e68qmv6kof4m57tsm8btg4lld25.apps.googleusercontent.com
+            client-secret: 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
             redirect-uri: "{baseUrl}/oauth2/callback/{registrationId}"
             scope:
               - profile
               - email
+          naver :
+            client-id: QGTNlYyb0W6QbHQDQWMl
+            client-secret: qCggzbFf_s
+            redirect-uri: "{baseUrl}/oauth2/callback/{registrationId}"
+            authorization-grant-type: authorization_code
+            client-name: Naver
+            scope:
+              - profile_image
+              - email
+              
+        provider:
+          naver:
+            authorization_uri: https://nid.naver.com/oauth2.0/authorize
+            token_uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user_name_attribute: response
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
           github :
             client-id: d0797abc068a3693fe26
             client-secret: e79d87694a09d16d6870644750e59aee26b0fe89
-            redirect-uri: "{baseUrl}/login/oauth2/callback/{registrationId}"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
             scope:
               - user:email
               - read:user

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -12,6 +12,13 @@ spring:
             scope:
               - user:email
               - read:user
+          google :
+            client-id: 152773267174-t42hi5dpk4pulm7ljssnf331itoipgck.apps.googleusercontent.com
+            client-secret: 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
+            redirect-uri: "{baseUrl}/oauth2/callback/{registrationId}"
+            scope:
+              - profile
+              - email
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -2,6 +2,17 @@ spring:
   security:
     filter:
       dispatcher-types: request
+    oauth2:
+      client:
+        registration:
+          github :
+            client-id: d0797abc068a3693fe26
+            client-secret: e79d87694a09d16d6870644750e59aee26b0fe89
+            redirect-uri: "{baseUrl}/login/oauth2/callback/{registrationId}"
+            scope:
+              - user:email
+              - read:user
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://localhost:3306/moa2?serverTimezone=Asia/Seoul&characterEncoding=UTF-8

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -1,7 +1,5 @@
 spring:
   security:
-    filter:
-      dispatcher-types: request
     oauth2:
       client:
         registration:

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
           github :
             client-id: d0797abc068a3693fe26
             client-secret: e79d87694a09d16d6870644750e59aee26b0fe89
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/oauth2/callback/{registrationId}"
             scope:
               - user:email
               - read:user

--- a/moa2/src/main/resources/application.yml
+++ b/moa2/src/main/resources/application.yml
@@ -33,7 +33,13 @@ spring:
       host: localhost
       port: 6379
 
-jwt:
-  secret: "ddhjfkafdshjlflhjdas3288998ksjkskj28kjas829uaw892jsa28jdska289kj289jdak28"
-  access-token-validity-in-seconds: 43200 # 12 hours
-  refresh-token-validity-in-seconds: 604800 # 1 week
+app:
+  jwt:
+    secret: "ddhjfkafdshjlflhjdas3288998ksjkskj28kjas829uaw89242kl4jk12j6jk1jjjsa28jdska289kj289jdak282313212412312"
+    access-token-validity-in-seconds: 43200 # 12 hours
+    refresh-token-validity-in-seconds: 604800 # 1 week
+  oauth2:
+    authorizedRedirectUris:
+      - http://localhost:3000/oauth2/redirect
+      - myandroidapp://oauth2/redirect
+      - myiosapp://oauth2/redirect

--- a/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
+++ b/moa2/src/test/java/com/moa2/security/jwt/JwtValidatorTest.java
@@ -1,8 +1,8 @@
 package com.moa2.security.jwt;
 
 import com.moa2.domain.member.Member;
-import com.moa2.dto.auth.LoginDto;
-import com.moa2.dto.auth.SignupDto;
+import com.moa2.dto.auth.request.LoginDto;
+import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.dto.auth.TokenDto;
 import com.moa2.exception.jwt.InvalidTokenRequestException;
 import com.moa2.repository.member.MemberRepository;

--- a/moa2/src/test/java/com/moa2/service/auth/AuthServiceTest.java
+++ b/moa2/src/test/java/com/moa2/service/auth/AuthServiceTest.java
@@ -1,8 +1,8 @@
 package com.moa2.service.auth;
 
 import com.moa2.domain.member.Member;
-import com.moa2.dto.auth.LoginDto;
-import com.moa2.dto.auth.SignupDto;
+import com.moa2.dto.auth.request.LoginDto;
+import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.repository.member.MemberRepository;
 import com.moa2.repository.redis.RedisRepository;
 import com.moa2.security.jwt.JwtValidator;

--- a/moa2/src/test/java/com/moa2/service/member/MemberServiceTest.java
+++ b/moa2/src/test/java/com/moa2/service/member/MemberServiceTest.java
@@ -1,7 +1,7 @@
 package com.moa2.service.member;
 
 import com.moa2.domain.member.Member;
-import com.moa2.dto.auth.SignupDto;
+import com.moa2.dto.auth.request.SignupDto;
 import com.moa2.repository.member.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## ⭐Key Changes
1. oauth2 를 이용한 로그인 시스템을 만들었습니다.
  - social login 성공 시 201 code 와 함께 AT 와 RT 와 지급되어 해당 토큰들로 기타 api와 연동해 인증, 인가 작업을 진행할 수 있습니다.
  - social login 실패 시 401 code 와 함께 에러 메시지가 출력됩니다 (ex - 이미 다른 social 로 만들어진 email 이 있는 경우)
2. authentication controller 의 response data 를 프론트와 상의한 format 에 맞게 수정하였습니다.

## 📌 issue
close #이슈번호

## Next move
oauth2 를 보수하고 테스트할 방법을 찾아보겠습니다.
oauth2 를 이용해 로그인 성공 시 jssesion token 이 생성되고 있는데 AT,RT 를 사용하고 있기 때문에 필요없는지 확인한 후 필요 없다면 발급되지 않게 하겠습니다.