### PR TITLE
Moa3/at in header

### DIFF
--- a/moa3/src/main/java/com/moa/moa3/dto/auth/LoginResponse.java
+++ b/moa3/src/main/java/com/moa/moa3/dto/auth/LoginResponse.java
@@ -9,7 +9,6 @@ public class LoginResponse {
     private String email;
     private String imageUrl;
     private boolean firstLogin;
-    private String accessToken;
     private Long refreshTokenExpirationInMilliSeconds;
 
     public LoginResponse(LoginSuccess loginSuccess, Long refreshTokenExpirationInMilliSeconds){
@@ -17,7 +16,6 @@ public class LoginResponse {
         this.email = loginSuccess.getEmail();
         this.imageUrl = loginSuccess.getImageUrl();
         this.firstLogin = loginSuccess.isFirstLogin();
-        this.accessToken = loginSuccess.getAccessToken();
         this.refreshTokenExpirationInMilliSeconds = refreshTokenExpirationInMilliSeconds;
     }
 }

--- a/moa3/src/main/java/com/moa/moa3/dto/auth/RefreshResponse.java
+++ b/moa3/src/main/java/com/moa/moa3/dto/auth/RefreshResponse.java
@@ -4,11 +4,9 @@ import lombok.Data;
 
 @Data
 public class RefreshResponse {
-    private String accessToken;
     private Long refreshTokenExpirationInMilliSeconds;
 
-    public RefreshResponse(String accessToken, Long refreshTokenExpirationInMilliSeconds) {
-        this.accessToken = accessToken;
+    public RefreshResponse(Long refreshTokenExpirationInMilliSeconds) {
         this.refreshTokenExpirationInMilliSeconds = refreshTokenExpirationInMilliSeconds;
     }
 }

--- a/moa3/src/main/java/com/moa/moa3/jwt/JwtTokenProvider.java
+++ b/moa3/src/main/java/com/moa/moa3/jwt/JwtTokenProvider.java
@@ -4,6 +4,7 @@ import com.moa.moa3.dto.jwt.AtRt;
 import com.moa.moa3.security.MemberDetails;
 import com.moa.moa3.service.redis.AccessTokenService;
 import com.moa.moa3.service.redis.RefreshTokenService;
+import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -32,6 +33,14 @@ public class JwtTokenProvider {
     @PostConstruct
     protected void init() {
         key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 
     public String createAccessToken(Authentication authentication) {

--- a/moa3/src/main/java/com/moa/moa3/jwt/JwtTokenService.java
+++ b/moa3/src/main/java/com/moa/moa3/jwt/JwtTokenService.java
@@ -2,17 +2,13 @@ package com.moa.moa3.jwt;
 
 import com.moa.moa3.dto.jwt.AtRt;
 import com.moa.moa3.entity.member.Member;
-import com.moa.moa3.repository.member.MemberRepository;
 import com.moa.moa3.security.MemberDetails;
+import com.moa.moa3.service.member.MemberService;
 import com.moa.moa3.service.redis.AccessTokenService;
 import com.moa.moa3.service.redis.RefreshTokenService;
 import com.moa.moa3.validation.jwt.JwtTokenValidator;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
-import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -20,45 +16,28 @@ import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-import java.security.Key;
 import java.util.Collection;
 
 @Component
 @RequiredArgsConstructor
 public class JwtTokenService {
-    @Value("${jwt.secret}")
-    private String secretKey;
-    private Key key;
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
     private final JwtTokenValidator jwtTokenValidator;
     private final JwtTokenProvider jwtTokenProvider;
     private final AccessTokenService accessTokenService;
     private final RefreshTokenService refreshTokenService;
 
-    @PostConstruct
-    protected void init() {
-        key = Keys.hmacShaKeyFor(secretKey.getBytes());
-    }
-
-    private Claims getClaims(String token) {
-        jwtTokenValidator.validateToken(token);
-        return Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-    }
 
     private Authentication createAuthentication(String token) {
-        Claims claims = getClaims(token);
+        jwtTokenValidator.validateToken(token);
+        Claims claims = jwtTokenProvider.getClaims(token);
 
         Collection<? extends GrantedAuthority> authorities = AuthorityUtils
                 .commaSeparatedStringToAuthorityList(claims.get("authorities").toString());
         Long memberId = claims.get("memberId", Long.class);
 
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+        Member member = memberService.findById(memberId);
         MemberDetails memberDetails = new MemberDetails(member);
 
         return new UsernamePasswordAuthenticationToken(memberDetails, token, authorities);
@@ -100,6 +79,8 @@ public class JwtTokenService {
     }
 
     public Long getTokenExpirationInMilliseconds(String token) {
-        return getClaims(token).getExpiration().getTime();
+        jwtTokenValidator.validateToken(token);
+        Claims claims = jwtTokenProvider.getClaims(token);
+        return claims.getExpiration().getTime();
     }
 }

--- a/moa3/src/main/java/com/moa/moa3/service/member/MemberService.java
+++ b/moa3/src/main/java/com/moa/moa3/service/member/MemberService.java
@@ -41,4 +41,9 @@ public class MemberService {
         return member;
     }
 
+    public Member findById(Long id) {
+        return memberRepository.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("해당 회원이 존재하지 않습니다.")
+        );
+    }
 }

--- a/moa3/src/main/java/com/moa/moa3/service/oauth/OAuthService.java
+++ b/moa3/src/main/java/com/moa/moa3/service/oauth/OAuthService.java
@@ -4,24 +4,15 @@ import com.moa.moa3.api.oauth.OAuthApi;
 import com.moa.moa3.dto.jwt.AtRt;
 import com.moa.moa3.dto.oauth.*;
 import com.moa.moa3.entity.member.Member;
-import com.moa.moa3.entity.member.MemberFactory;
-import com.moa.moa3.exception.oauth.DuplicateLoginFailureException;
-import com.moa.moa3.jwt.JwtTokenProvider;
 import com.moa.moa3.jwt.JwtTokenService;
-import com.moa.moa3.repository.member.MemberRepository;
-import com.moa.moa3.security.MemberDetails;
 import com.moa.moa3.service.member.MemberService;
+import com.moa.moa3.util.oauth.OAuthProvider;
 import com.moa.moa3.util.oauth.OAuthProviderFactory;
-import com.moa.moa3.util.oauth.userprofile.UserProfileMapperFactory;
-import com.moa.moa3.validation.jwt.JwtTokenValidator;
+import com.moa.moa3.util.oauth.userprofile.UserProfileExtractor;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/moa3/src/main/java/com/moa/moa3/util/oauth/userprofile/UserProfileExtractor.java
+++ b/moa3/src/main/java/com/moa/moa3/util/oauth/userprofile/UserProfileExtractor.java
@@ -11,7 +11,6 @@ public enum UserProfileExtractor {
         @Override
         public UserProfile of(Map<String, Object> attributes) {
             return UserProfile.builder()
-                    .oAuthId(String.valueOf(attributes.get("id")))
                     .email(String.valueOf(attributes.get("email")))
                     .name(String.valueOf(attributes.get("name")))
                     .imageUrl(String.valueOf(attributes.get("avatar_url")))


### PR DESCRIPTION
## ⭐Key Changes
jwt 와 oauth 를 활용한 로그인 서비스에서 기존에는 access token 이 json 의 형태로 body 에 담겨서 response 되었습니다.
이를 header 에 넣어서 전달되는 것으로 변경하였습니다.

스펙은 header 에 저장되는 스펙은 "Bearer {access token}" 으로 통용되는 스펙을 따랐습니다.
